### PR TITLE
Fixing mocked asyncWithLDProvider to return Promise

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -40,6 +40,20 @@ describe('main', () => {
     expect(asyncWithLDProvider).toBeDefined()
   })
 
+  test('mock asyncWithLDProvider returns promise of a value function', (done) => {
+    const providerPromise = asyncWithLDProvider({ clientSideID: 'someid' });
+
+    expect(providerPromise).toBeInstanceOf(Promise)
+
+    providerPromise.then(provider => {
+      expect(provider).toBeInstanceOf(Function)
+
+      expect(provider({ children: 'child' })).toEqual('child')
+
+      done()
+    })
+  })
+
   test('mock LDProvider correctly', () => {
     expect(LDProvider).toBeDefined()
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ export const ldClientMock = {
   waitUntilReady: jest.fn(),
 }
 
-mockAsyncWithLDProvider.mockImplementation(() => (children: any) => children)
+mockAsyncWithLDProvider.mockImplementation(() => Promise.resolve((props: any) => props.children))
 mockLDProvider.mockImplementation((children: any) => children)
 mockUseLDClient.mockImplementation(() => ldClientMock)
 mockWithLDConsumer.mockImplementation(() => () => null)


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

https://github.com/launchdarkly/jest-launchdarkly-mock/issues/16

**Describe the solution you've provided**

This is a fix for `mockAsyncWithLDProvider`. From the docs `asyncWithLDProvider` should return a Promise. This promise should resolved to a React component. This resolved React component on the good path, should render the children that are passed to it through its props.

**Describe alternatives you've considered**

**Additional context**
