### PR TITLE
fix: mockWithLDConsumer should not return null

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ export const ldClientMock = {
 mockAsyncWithLDProvider.mockImplementation(() => Promise.resolve((props: any) => props.children))
 mockLDProvider.mockImplementation((children: any) => children)
 mockUseLDClient.mockImplementation(() => ldClientMock)
-mockWithLDConsumer.mockImplementation(() => () => null)
+mockWithLDConsumer.mockImplementation(() => (children: any) => children)
 mockWithLDProvider.mockImplementation(() => (children: any) => children)
 
 export const mockFlags = (flags: LDFlagSet) => {


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**
- Fixes #28

**Describe the solution you've provided**

Currently the mock for `WithLDConsumer` returns `null` which leads to errors such as below:

![Screenshot 2022-05-23 at 20 01 15](https://user-images.githubusercontent.com/15277963/169879805-b0f20dc1-4b10-4b62-90c6-06775be0e434.png)

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
