### PR TITLE
Fix missing useLDClientError function

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react-hooks'
-import { useFlags, useLDClient, LDProvider, asyncWithLDProvider } from 'launchdarkly-react-client-sdk'
+import { useFlags, useLDClient, useLDClientError, LDProvider, asyncWithLDProvider } from 'launchdarkly-react-client-sdk'
 import { mockFlags, ldClientMock, resetLDMocks } from './index'
 
 describe('main', () => {
@@ -34,6 +34,10 @@ describe('main', () => {
 
     expect(current.DEV_test_Flag).toBeTruthy()
     expect(current['DEV_test_Flag']).toBeTruthy()
+  })
+
+  test('mock useLDClientError correctly', () => {
+    expect(useLDClientError).toBeDefined()
   })
 
   test('mock asyncWithLDProvider correctly', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ jest.mock('launchdarkly-react-client-sdk', () => {
     LDProvider: jest.fn(),
     useLDClient: jest.fn(),
     useFlags: jest.fn(),
+    useLDClientError: jest.fn(),
     withLDConsumer: jest.fn(),
     withLDProvider: jest.fn(),
   }


### PR DESCRIPTION
**Requirements**

- [X] I have added test coverage for new or changed functionality
- [X] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [X] I have validated my changes against all supported platform versions

**Related issues**

Fixes #47 

**Describe the solution you've provided**

Adds `useLDClientError` to the mocks list.
