### PR TITLE
mockUseFlags should return an empty object

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 ## Contributing to jest-launchdarkly-mock
  
-LaunchDarkly has published an [SDK contributor's guide](https://docs.launchdarkly.com/docs/sdk-contributors-guide) that 
+LaunchDarkly has published an [SDK contributor's guide](https://docs.launchdarkly.com/sdk/concepts/contributors-guide) that 
 provides a detailed explanation of how our SDKs work. See below for additional information on how to contribute to 
 this mock library.
  

--- a/example/src/universal/components/button.test.tsx
+++ b/example/src/universal/components/button.test.tsx
@@ -9,6 +9,11 @@ describe('button', () => {
     resetLDMocks()
   })
 
+  it('flags are falsey when not explicity mocked with mockFlags', () => {
+    const { getByText } = render(<Button />)
+    expect(getByText('button disabled')).toBeTruthy()
+  })
+
   // mocking camelCased flags
   it('camelCased flag on', () => {
     mockFlags({ devTestFlag: true })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -107,7 +107,7 @@ describe('main', () => {
     expect(current2).toEqual({})
   })
 
-  test('initial mockFlags value', () => {
+  test('initial useFlags value', () => {
     const {
       result: { current },
     } = renderHook(() => useFlags())

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -91,11 +91,28 @@ describe('main', () => {
 
   test('reset all flag mocks', () => {
     mockFlags({ devTestFlag: true })
-    renderHook(() => useFlags())
+
+    const {
+      result: { current },
+    } = renderHook(() => useFlags())
+
+    expect(current.devTestFlag).toBeTruthy()
 
     resetLDMocks()
 
-    expect(useFlags).not.toHaveBeenCalled()
+    const {
+      result: { current: current2 },
+    } = renderHook(() => useFlags())
+
+    expect(current2).toEqual({})
+  })
+
+  test('initial mockFlags value', () => {
+    const {
+      result: { current },
+    } = renderHook(() => useFlags())
+
+    expect(current).toEqual({})
   })
 
   test('reset ldClientMock ', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ jest.mock('launchdarkly-react-client-sdk', () => {
     camelCaseKeys,
     LDProvider: jest.fn(),
     useLDClient: jest.fn(),
-    useFlags: jest.fn(),
+    useFlags: jest.fn(() => ({})),
     useLDClientError: jest.fn(),
     withLDConsumer: jest.fn(),
     withLDProvider: jest.fn(),
@@ -75,7 +75,7 @@ export const mockFlags = (flags: LDFlagSet) => {
 }
 
 export const resetLDMocks = () => {
-  mockUseFlags.mockReset()
+  mockUseFlags.mockImplementation(() => ({}))
 
   Object.keys(ldClientMock).forEach((k) => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions
	**sorry not sure what this means ^** 

**Related issues**
https://github.com/launchdarkly/jest-launchdarkly-mock/issues/55

**Describe the solution you've provided**
When [jest-launchdarkly-mock](https://github.com/launchdarkly/jest-launchdarkly-mock) is added to a jest config, `useFlags()` calls will now return an empty object by default, which matches its actual implementation 

**Additional context**
- Updated SDK contributor's guide link as current one is dead
- Modified 'reset all flag mocks' test to better represent the affect `resetLDMocks()` has on `mockUseFlags`


Thanks! 😀
