### PR TITLE
Prevent resetMocks: true from clearing mock implementations

### DIFF
--- a/example/jest.config.js
+++ b/example/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   preset: 'ts-jest',
+  resetMocks: true,
   setupFiles: ['jest-launchdarkly-mock'],
   testEnvironment: 'jsdom',
   testPathIgnorePatterns: ['tsoutput'],

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   preset: 'ts-jest',
   setupFiles: ['./src/index.ts'],
+  resetMocks: true,
   testPathIgnorePatterns: ['<rootDir>/example/', '<rootDir>/node_modules/'],
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,8 +1,12 @@
 import { renderHook } from '@testing-library/react-hooks'
 import { useFlags, useLDClient, useLDClientError, LDProvider, asyncWithLDProvider } from 'launchdarkly-react-client-sdk'
-import { mockFlags, ldClientMock, resetLDMocks } from './index'
+import { mockFlags, ldClientMock, resetLDMocks, setupMocks } from './index'
 
 describe('main', () => {
+  beforeEach(() => {
+    setupMocks()
+  })
+
   test('mock kebab-case correctly', () => {
     mockFlags({ 'dev-test-flag': true })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,13 +49,17 @@ export const ldClientMock = {
   waitUntilReady: jest.fn(),
 }
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-mockAsyncWithLDProvider.mockImplementation(() => Promise.resolve((props: any) => props.children))
-mockLDProvider.mockImplementation((props: any) => props.children)
-mockUseLDClient.mockImplementation(() => ldClientMock)
-mockWithLDConsumer.mockImplementation(() => (children: any) => children)
-mockWithLDProvider.mockImplementation(() => (children: any) => children)
-/* eslint-enable @typescript-eslint/no-explicit-any */
+export const setupMocks = () => {
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  mockAsyncWithLDProvider.mockImplementation(() => Promise.resolve((props: any) => props.children))
+  mockLDProvider.mockImplementation((props: any) => props.children)
+  mockUseLDClient.mockImplementation(() => ldClientMock)
+  mockUseFlags.mockImplementation(() => ({}))
+  mockWithLDConsumer.mockImplementation(() => (children: any) => children)
+  mockWithLDProvider.mockImplementation(() => (children: any) => children)
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+}
+setupMocks()
 
 export const mockFlags = (flags: LDFlagSet) => {
   mockUseFlags.mockImplementation(() => {
@@ -75,7 +79,7 @@ export const mockFlags = (flags: LDFlagSet) => {
 }
 
 export const resetLDMocks = () => {
-  mockUseFlags.mockImplementation(() => ({}))
+  setupMocks()
 
   Object.keys(ldClientMock).forEach((k) => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Describe the solution you've provided**

If a team uses [`resetMocks: true`](https://jestjs.io/docs/configuration#resetmocks-boolean) in their jest config then the mocked functions of `launchdarkly-react-client-sdk` will return undefined during test execution. 

To allow teams using `resetMocks` to use this package I have pulled the mock implementations into a `setupMocks` function that can be called in `beforeEach`.

I haven't updated the documentation to explain this usecase, I'd value feedback on where / how to do that. 