### PR TITLE
Memoize mockFlags result

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -58,18 +58,17 @@ mockWithLDProvider.mockImplementation(() => (children: any) => children)
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
 export const mockFlags = (flags: LDFlagSet) => {
+  const result: LDFlagSet = {}
+  Object.keys(flags).forEach((k) => {
+    const kebab = kebabCase(k)
+    const camel = camelCase(k)
+    const snake = snakeCase(k)
+    result[kebab] = flags[k]
+    result[camel] = flags[k]
+    result[snake] = flags[k]
+    result[k] = flags[k]
+  })
   mockUseFlags.mockImplementation(() => {
-    const result: LDFlagSet = {}
-    Object.keys(flags).forEach((k) => {
-      const kebab = kebabCase(k)
-      const camel = camelCase(k)
-      const snake = snakeCase(k)
-      result[kebab] = flags[k]
-      result[camel] = flags[k]
-      result[snake] = flags[k]
-      result[k] = flags[k]
-    })
-
     return result
   })
 }


### PR DESCRIPTION
This PR changes the mockFlags function so that it doesn't create a new object inside the mockImplementation.

This fixes for instance React components wrapping `useFlags` inside a `useMemo`, which right now in a Jest environment doesn't work because it is a new object every time - while in a browser/real environment it is not.
