### PR TITLE
Mock addHook from launchdarkly-js-sdk-common

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -73,15 +73,16 @@ describe('main', () => {
   })
 
   test('ldClient mock has complete set of methods', () => {
-    expect(ldClientMock.track.mock).toBeDefined()
-    expect(ldClientMock.identify.mock).toBeDefined()
+    expect(ldClientMock.addHook.mock).toBeDefined()
     expect(ldClientMock.allFlags.mock).toBeDefined()
     expect(ldClientMock.close.mock).toBeDefined()
     expect(ldClientMock.flush.mock).toBeDefined()
     expect(ldClientMock.getContext.mock).toBeDefined()
+    expect(ldClientMock.identify.mock).toBeDefined()
     expect(ldClientMock.off.mock).toBeDefined()
     expect(ldClientMock.on.mock).toBeDefined()
     expect(ldClientMock.setStreaming.mock).toBeDefined()
+    expect(ldClientMock.track.mock).toBeDefined()
     expect(ldClientMock.variation.mock).toBeDefined()
     expect(ldClientMock.variationDetail.mock).toBeDefined()
     expect(ldClientMock.waitForInitialization.mock).toBeDefined()

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,15 +33,16 @@ const mockWithLDConsumer = withLDConsumer as jest.Mock
 const mockWithLDProvider = withLDProvider as jest.Mock
 
 export const ldClientMock = {
-  track: jest.fn(),
-  identify: jest.fn(),
+  addHook: jest.fn(),
   allFlags: jest.fn(),
   close: jest.fn(),
   flush: jest.fn(),
   getContext: jest.fn(),
+  identify: jest.fn(),
   off: jest.fn(),
   on: jest.fn(),
   setStreaming: jest.fn(),
+  track: jest.fn(),
   variation: jest.fn(),
   variationDetail: jest.fn(),
   waitForInitialization: jest.fn(),


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

Not directly related, but I upvoted for adding/moving to support for Vitest, [here](https://github.com/launchdarkly/jest-launchdarkly-mock/issues/56)

Once this is merged, I will have to do a PR or file an issue on https://github.com/bohdanbirdie/vitest-launchdarkly-mock

**Describe the solution you've provided**

We were getting CI errors in tests that are mocking LDClient, specifically about the recently-added `addHook` method. This mocks it using `jest.fn()`, same as all other methods

**Describe alternatives you've considered**

None. Doing this so that it can then be ported to https://github.com/bohdanbirdie/vitest-launchdarkly-mock

**Additional context**

Add any other context about the pull request here.
